### PR TITLE
CLLocationManager not imported, build fails

### DIFF
--- a/OCPrayerTimes/PrayTime.h
+++ b/OCPrayerTimes/PrayTime.h
@@ -18,6 +18,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreLocation/CLLocationManager.h>
 
 /** 
  * These constants are used to specify the prayer times calculation method. 


### PR DESCRIPTION
The build fails because CLLocationManager is not imported. I just added that to the .h file.

Jazakallahu khair for your work!
